### PR TITLE
Update version with new Device dependnecy version

### DIFF
--- a/Example/Cartfile
+++ b/Example/Cartfile
@@ -2,5 +2,5 @@
 git "file:///path/to/RSFontSizes" "branch_name"
 
 # Release
-github "rootstrap/RSFontSizes" ~> 1.3.0
+github "rootstrap/RSFontSizes" ~> 1.3.2
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -10,13 +10,4 @@ target 'RSFontSizes_Example' do
     pod 'Quick', '~> 2.0.0'
     pod 'Nimble', '~> 8.0.1'
   end
-  
-  post_install do |lib|
-    lib.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.0'
-      end
-    end
-  end
-  
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Ekhoo/Device.git",
       "state" : {
-        "revision" : "891a47647ea718723d9b0279a0356fe04a616ff8",
-        "version" : "3.4.0"
+        "revision" : "50054824ed26a6a0deb58c47480903eaaa4ec5dd",
+        "version" : "3.5.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Ekhoo/Device.git", from: "3.4.0")
+        .package(url: "https://github.com/Ekhoo/Device.git", from: "3.5.0")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pod "RSFontSizes"
 1. Add the following sources to your Cartfile:
 
 ```
-github "rootstrap/RSFontSizes" ~> 1.3.0
+github "rootstrap/RSFontSizes" ~> 1.3.2
 ```
 
 2. Run the `carthage update` command in the terminal.

--- a/RSFontSizes.podspec
+++ b/RSFontSizes.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'RSFontSizes'
-  s.version          = '1.3.1'
+  s.version          = '1.3.2'
   s.summary          = 'Easily manage your font styles and sizes for every screen size.'
 
 # This description is used to generate tags and improve search results.
@@ -33,5 +33,5 @@ Pod::Spec.new do |s|
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'Device', '~> 3.4.0'
+  s.dependency 'Device', '~> 3.5.0'
 end


### PR DESCRIPTION
This version updates the Device dependency to 3.5.0 which includes necessary changes to compile correctly on Xcode 14.3 and up. 
See [this issue](https://github.com/Ekhoo/Device/issues/123) for more details